### PR TITLE
add -f option to curl to fail on HTTP error

### DIFF
--- a/script/4.7.3
+++ b/script/4.7.3
@@ -101,7 +101,7 @@ for ARCHIVE in $ARCHIVE_LIST; do
         exit 1
       fi
     else
-      if ! curl $ARCHIVE -L -o $FILE; then
+      if ! curl -f $ARCHIVE -L -o $FILE; then
         rm $FILE
         exit 1
       fi

--- a/script/4.8.4
+++ b/script/4.8.4
@@ -101,7 +101,7 @@ for ARCHIVE in $ARCHIVE_LIST; do
         exit 1
       fi
     else
-      if ! curl $ARCHIVE -L -o $FILE; then
+      if ! curl -f $ARCHIVE -L -o $FILE; then
         rm $FILE
         exit 1
       fi

--- a/script/4.8.5
+++ b/script/4.8.5
@@ -101,7 +101,7 @@ for ARCHIVE in $ARCHIVE_LIST; do
         exit 1
       fi
     else
-      if ! curl $ARCHIVE -L -o $FILE; then
+      if ! curl -f $ARCHIVE -L -o $FILE; then
         rm $FILE
         exit 1
       fi

--- a/script/4.9.2
+++ b/script/4.9.2
@@ -101,7 +101,7 @@ for ARCHIVE in $ARCHIVE_LIST; do
         exit 1
       fi
     else
-      if ! curl $ARCHIVE -L -o $FILE; then
+      if ! curl -f $ARCHIVE -L -o $FILE; then
         rm $FILE
         exit 1
       fi

--- a/script/4.9.3
+++ b/script/4.9.3
@@ -101,7 +101,7 @@ for ARCHIVE in $ARCHIVE_LIST; do
         exit 1
       fi
     else
-      if ! curl $ARCHIVE -L -o $FILE; then
+      if ! curl -f $ARCHIVE -L -o $FILE; then
         rm $FILE
         exit 1
       fi

--- a/script/5.1.0
+++ b/script/5.1.0
@@ -101,7 +101,7 @@ for ARCHIVE in $ARCHIVE_LIST; do
         exit 1
       fi
     else
-      if ! curl $ARCHIVE -L -o $FILE; then
+      if ! curl -f $ARCHIVE -L -o $FILE; then
         rm $FILE
         exit 1
       fi

--- a/script/5.2.0
+++ b/script/5.2.0
@@ -101,7 +101,7 @@ for ARCHIVE in $ARCHIVE_LIST; do
         exit 1
       fi
     else
-      if ! curl $ARCHIVE -L -o $FILE; then
+      if ! curl -f $ARCHIVE -L -o $FILE; then
         rm $FILE
         exit 1
       fi


### PR DESCRIPTION
Otherwise curl will output downloaded error message (e.g. 404 Not found)
in to the output file.

This is the default behaviour of wget.