### PR TITLE
fix download links for 5.2.0

### DIFF
--- a/script/5.2.0
+++ b/script/5.2.0
@@ -26,9 +26,9 @@ AUTOCONF_VERSION=2.64
 AUTOMAKE_VERSION=1.11.1
 
 # tarball location
-BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/current/v2gnu/bnu${BINUTILS_VERSION}s.zip"
-DJCRX_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/beta/v2/djcrx${DJCRX_VERSION}.zip"
-DJLSR_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/beta/v2/djlsr${DJLSR_VERSION}.zip"
+BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"
+DJCRX_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/current/v2/djcrx${DJCRX_VERSION}.zip"
+DJLSR_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/current/v2/djlsr${DJLSR_VERSION}.zip"
 
 DJCROSS_GCC_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/rpms/djcross-gcc-${GCC_VERSION}/djcross-gcc-${GCC_VERSION}.tar.bz2"
 GCC_ARCHIVE="http://ftpmirror.gnu.org/gcc/gcc-${GCC_VERSION}/gcc-${GCC_VERSION}.tar.bz2"


### PR DESCRIPTION
They probably won't live long, especially one in the "deleted"
directory.