### PR TITLE
fixup setenv.bat

### DIFF
--- a/setenv/setenv.bat
+++ b/setenv/setenv.bat
@@ -1,4 +1,4 @@
 @echo off
-PATH=%~dp0\i586-pc-msdosdjgpp\bin;%~dp0\bin;%PATH
-set GCC_EXEC_PREFIX=%~dp0\lib\gcc\
-set DJDIR=%~dp0\i586-pc-msdosdjgpp
+PATH=%~dp0i586-pc-msdosdjgpp\bin;%~dp0bin;%PATH%
+set GCC_EXEC_PREFIX=%~dp0lib\gcc\
+set DJDIR=%~dp0i586-pc-msdosdjgpp


### PR DESCRIPTION
Fixes some errors in setenv.bat on Windows that resulted in a non-working compiler and eradication of the nominal PATH environment.