### PR TITLE
Patch gcc 4 compilation

### DIFF
--- a/script/4.7.3
+++ b/script/4.7.3
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+CFLAGS="-O2 -g $CFLAGS -std=gnu90"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/4.8.4
+++ b/script/4.8.4
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+CFLAGS="-O2 -g $CFLAGS -std=gnu90"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/4.8.5
+++ b/script/4.8.5
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+CFLAGS="-O2 -g $CFLAGS -std=gnu90"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/4.9.2
+++ b/script/4.9.2
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+CFLAGS="-O2 -g $CFLAGS -std=gnu90"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/4.9.3
+++ b/script/4.9.3
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+CFLAGS="-O2 -g $CFLAGS -std=gnu90"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/4.9.4
+++ b/script/4.9.4
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+CFLAGS="-O2 -g $CFLAGS -std=gnu90"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}sr3.zip"

--- a/script/5.1.0
+++ b/script/5.1.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/5.2.0
+++ b/script/5.2.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/5.3.0
+++ b/script/5.3.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/5.4.0
+++ b/script/5.4.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}sr3.zip"

--- a/script/6.1.0
+++ b/script/6.1.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/6.2.0
+++ b/script/6.2.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}sr3.zip"

--- a/script/6.3.0
+++ b/script/6.3.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/6.4.0
+++ b/script/6.4.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/7.1.0
+++ b/script/7.1.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/deleted/v2gnu/bnu${BINUTILS_VERSION}s.zip"

--- a/script/7.2.0
+++ b/script/7.2.0
@@ -32,11 +32,14 @@ CXX=g++
 # use gmake under FreeBSD
 if [ `uname` = "FreeBSD" ]; then
   MAKE=gmake
-  export CC=clang
-  export CXX=clang++
+  CC=clang
+  CXX=clang++
 else
   MAKE=make
 fi
+#CFLAGS="-O2 -g $CFLAGS -std=gnu11"
+
+export CC CXX CFLAGS MAKE
 
 # tarball location
 BINUTILS_ARCHIVE="${DJGPP_DOWNLOAD_BASE}/djgpp/current/v2gnu/bnu${BINUTILS_VERSION}s.zip"


### PR DESCRIPTION
Note: without this patch  the following error is raised when running `make` in build-djgpp-master/build/djcross-gcc-4.7.3/djcross/gcc/cp/except.c:

~~~
cfns.gperf: At top level:
cfns.gperf:101:1: error: 'gnu_inline' attribute present on 'libc_name_p'
cfns.gperf:26:14: error: but not here
~~~

Mike Frysinger explained the reason for the error in https://gcc.gnu.org/ml/gcc-patches/2015-08/msg00375.html and from inspecting the sources he provided the patch for it looks like build_dgjpp tried to patch the file, too (without any benefit as shown above). But the *real* fix is much more likely to *always* compile all "old" sources with `-std=gnu90` as outlined in [Porting to GCC 5](https://gcc.gnu.org/gcc-5/porting_to.html) - not only for GCC itself (where it breaks) but for all compilations when compiling pre-5 (GCC4 has the same option, therefore it doesn't harm to hard-wire it in the 4.7.3 script).

This is what the PR does. Additionally it `export`s the main compilation identifiers that are set in the beginning.

Note: Another point mentioned in the GCC5 porting doc is the new 
>  warning: ISO C does not support '__FUNCTION__' predefined identifier [-Wpedantic]

As this is heavily used in GCC most of the compilation messages are full of it - it would be nice to disable it but I did not found a quick option:

* `-Wno-pedantic` in CFLAGS doesn't work as `-pedantic` is passed later and this re-activates the warning
* we could patch *all* configure/Makefile to remove it but this looks like very much too do
