### PR TITLE
fix missing include (dxe fails to build) because of non-recursive unzip

### DIFF
--- a/script/4.7.3
+++ b/script/4.7.3
@@ -329,7 +329,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/4.8.4
+++ b/script/4.8.4
@@ -330,7 +330,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/4.8.5
+++ b/script/4.8.5
@@ -330,7 +330,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/4.9.2
+++ b/script/4.9.2
@@ -330,7 +330,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/4.9.3
+++ b/script/4.9.3
@@ -330,7 +330,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/4.9.4
+++ b/script/4.9.4
@@ -330,7 +330,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/5.1.0
+++ b/script/5.1.0
@@ -331,7 +331,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/5.2.0
+++ b/script/5.2.0
@@ -331,7 +331,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/5.3.0
+++ b/script/5.3.0
@@ -331,7 +331,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/5.4.0
+++ b/script/5.4.0
@@ -331,7 +331,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/6.1.0
+++ b/script/6.1.0
@@ -331,7 +331,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/6.2.0
+++ b/script/6.2.0
@@ -331,7 +331,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/6.3.0
+++ b/script/6.3.0
@@ -334,7 +334,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/6.4.0
+++ b/script/6.4.0
@@ -339,7 +339,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/7.1.0
+++ b/script/7.1.0
@@ -334,7 +334,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1

--- a/script/7.2.0
+++ b/script/7.2.0
@@ -334,7 +334,7 @@ rm -rf djlsr${DJLSR_VERSION}
 mkdir djlsr${DJLSR_VERSION}
 cd djlsr${DJLSR_VERSION}
 unzip ../../download/djlsr${DJLSR_VERSION}.zip || exit 1
-unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
+unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
 patch -p1 -u < ../../patch/patch-djlsr205.txt || exit 1
 cd src
 PATH=$DJGPP_PREFIX/bin/:$PATH make || exit 1


### PR DESCRIPTION
Note: occurs both when running `./build-djgpp.sh 7.2.0` (directly) and when running `./build-djgpp.sh 4.7.3` (after fixing other issues by changes provided in in https://github.com/andrewwutw/build-djgpp/pull/20).

~~~
make -C stub native
gcc -g -O2 stub2inc.c -o stub2inc.exe
./stub2inc.exe stub.map stub.asm ./../../include/stubinfo.h
gcc -g -O2 stubedit.c -o ../../hostbin/stubedit.exe
./../../hostbin/djasm.exe stub.asm stub.h stub.map
0x5e7 bytes generated, 0x600 bytes in file, 0x870 bytes total, 137 symbols
gcc -g -O2 stubify.c -o ../../hostbin/stubify.exe
make -C utils native
gcc -g -O2 bin2h.c -o ../../hostbin/bin2h.exe
make -C dxe native
gcc -g -O2 -DDXE_LD=\"i586-pc-msdosdjgpp-ld\" -DDXE_CC=\"i586-pc-msdosdjgpp-gcc\" -DDXE_AR=\"i586-pc-msdosdjgpp-ar\" -DDXE_AS=\"i586-pc-msdosdjgpp-as\" dxe3gen.c -o ../../hostbin/dxegen.exe
dxe3gen.c:193:10: fatal error: ../../include/sys/dxe.h: No such file or directory
 #include "../../include/sys/dxe.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[1]: *** [../../hostbin/dxegen.exe] Error 1
make: *** [subs] Error 2
~~~

The reason is that these includes are actually downloaded but (at least on this system) not extracted.
The script does:
```
unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" || exit 1
```
but this leaves all sub-directories (like the missing sys`) out. Fixed by extracting them too:

```
unzip ../../download/djdev${DJDEV_VERSION}.zip "include/*" "include/*/*" || exit 1
```