### PR TITLE
Fixed DJGPP_DOWNLOAD_BASE, ftp seems to be changed

### DIFF
--- a/script/4.7.3
+++ b/script/4.7.3
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.8.4
+++ b/script/4.8.4
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.8.5
+++ b/script/4.8.5
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.9.2
+++ b/script/4.9.2
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.9.3
+++ b/script/4.9.3
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.9.4
+++ b/script/4.9.4
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/5.1.0
+++ b/script/5.1.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/5.2.0
+++ b/script/5.2.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/5.3.0
+++ b/script/5.3.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/5.4.0
+++ b/script/5.4.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/5.5.0
+++ b/script/5.5.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/6.1.0
+++ b/script/6.1.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/6.2.0
+++ b/script/6.2.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/6.3.0
+++ b/script/6.3.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=227

--- a/script/6.4.0
+++ b/script/6.4.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=227

--- a/script/7.1.0
+++ b/script/7.1.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=227

--- a/script/7.2.0
+++ b/script/7.2.0
@@ -10,7 +10,7 @@ DJGPP_PREFIX=${DJGPP_PREFIX-/usr/local/djgpp}
 ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="ftp://na.mirror.garr.it/mirrors"
 
 # source tarball versions
 BINUTILS_VERSION=229


### PR DESCRIPTION
FTP for sources seems to be changed, changed  DJGPP_DOWNLOAD_BASE to new address in scripts to "ftp://na.mirror.garr.it/mirrors".  
Tested with 7.2.0 (and partly 4.7.3), seems to be working.