### PR TITLE
These are GCC versions, not DJGPP versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ ENABLE_LANGUAGES=c,c++,f95,objc,obj-c++
 
 To build DJGPP, just run :
 
-./build-djgpp.sh *djgpp-version*
+./build-djgpp.sh *gcc-version*
 
-Currently supported djgpp-version :
+Currently supported gcc-version :
 
 * 4.7.3
 * 4.8.4

--- a/build-djgpp.sh
+++ b/build-djgpp.sh
@@ -3,16 +3,16 @@
 BUILD_VER=$1
 
 if [ -z $BUILD_VER ]; then
-  echo "Usage : $0 djgpp-version"
-  echo "Supported djgpp-version :"
+  echo "Usage : $0 gcc-version"
+  echo "Supported gcc-version :"
   for F in `(cd script/;echo *)`; do echo "  "$F; done
   exit 1
 fi
 
 if [ -x script/$BUILD_VER ]; then
-  echo "Building version : $BUILD_VER"
+  echo "Building with GCC version : $BUILD_VER"
   script/$BUILD_VER || exit 1
 else
-  echo "Unsupported version : $BUILD_VER"
+  echo "Unsupported GCC version : $BUILD_VER"
   exit 1
 fi


### PR DESCRIPTION
According to <https://www.delorie.com/djgpp/v2/>,
the current version of DJGPP is 2.05.

That certainly explains why the zips are named `dj*205.zip`,
and the fact that the directory names all start with `v2`.