### PR TITLE
Changed DJGPP_DOWNLOAD_BASE remote url into https.

### DIFF
--- a/script/10.1.0
+++ b/script/10.1.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=230

--- a/script/10.1.0
+++ b/script/10.1.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/10.2.0
+++ b/script/10.2.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=230

--- a/script/10.2.0
+++ b/script/10.2.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/10.3.0
+++ b/script/10.3.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=230

--- a/script/10.3.0
+++ b/script/10.3.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/12.1.0
+++ b/script/12.1.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=230

--- a/script/12.1.0
+++ b/script/12.1.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/4.7.3
+++ b/script/4.7.3
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.7.3
+++ b/script/4.7.3
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/4.8.4
+++ b/script/4.8.4
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.8.4
+++ b/script/4.8.4
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/4.8.5
+++ b/script/4.8.5
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.8.5
+++ b/script/4.8.5
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/4.9.2
+++ b/script/4.9.2
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.9.2
+++ b/script/4.9.2
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/4.9.3
+++ b/script/4.9.3
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/4.9.3
+++ b/script/4.9.3
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/4.9.4
+++ b/script/4.9.4
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/4.9.4
+++ b/script/4.9.4
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/5.1.0
+++ b/script/5.1.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/5.1.0
+++ b/script/5.1.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/5.2.0
+++ b/script/5.2.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/5.2.0
+++ b/script/5.2.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/5.3.0
+++ b/script/5.3.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/5.3.0
+++ b/script/5.3.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/5.4.0
+++ b/script/5.4.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/5.4.0
+++ b/script/5.4.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/5.5.0
+++ b/script/5.5.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/5.5.0
+++ b/script/5.5.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/6.1.0
+++ b/script/6.1.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=224

--- a/script/6.1.0
+++ b/script/6.1.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/6.2.0
+++ b/script/6.2.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=226

--- a/script/6.2.0
+++ b/script/6.2.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/6.3.0
+++ b/script/6.3.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=227

--- a/script/6.3.0
+++ b/script/6.3.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/6.4.0
+++ b/script/6.4.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=227

--- a/script/6.4.0
+++ b/script/6.4.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/6.5.0
+++ b/script/6.5.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=227

--- a/script/6.5.0
+++ b/script/6.5.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/7.1.0
+++ b/script/7.1.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=227

--- a/script/7.1.0
+++ b/script/7.1.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/7.2.0
+++ b/script/7.2.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/7.2.0
+++ b/script/7.2.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=229

--- a/script/7.3.0
+++ b/script/7.3.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/7.3.0
+++ b/script/7.3.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=229

--- a/script/7.5.0
+++ b/script/7.5.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/7.5.0
+++ b/script/7.5.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=229

--- a/script/8.3.0
+++ b/script/8.3.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=230

--- a/script/8.3.0
+++ b/script/8.3.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"

--- a/script/9.3.0
+++ b/script/9.3.0
@@ -14,10 +14,10 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
-FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTPMIRROR_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 #FTP_GNU_DOWNLOAD_BASE="http://ftp.gnu.org/gnu"
-FTP_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
+FTP_GNU_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.gnu.org/gnu"
 
 # source tarball versions
 BINUTILS_VERSION=230

--- a/script/9.3.0
+++ b/script/9.3.0
@@ -11,7 +11,7 @@ ENABLE_LANGUAGES=${ENABLE_LANGUAGES-c,c++}
 
 #DJGPP_DOWNLOAD_BASE="ftp://ftp.delorie.com/pub"
 #DJGPP_DOWNLOAD_BASE="http://www.delorie.com/pub"
-DJGPP_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.delorie.com/pub"
+DJGPP_DOWNLOAD_BASE="https://www.mirrorservice.org/sites/ftp.delorie.com/pub"
 
 #FTPMIRROR_GNU_DOWNLOAD_BASE="http://ftpmirror.gnu.org"
 FTPMIRROR_GNU_DOWNLOAD_BASE="http://www.mirrorservice.org/sites/ftp.gnu.org/gnu"


### PR DESCRIPTION
The ISP from the country I'm living in is doing something behind the stage and it cause download failed on "http". I changed it into "https" and it download really fast.

I don't think there are machines that doesn't support https protocol on this decade. This PR is optional.