### PR TITLE
Fix compilation of version 7.2.0 using GCC 15.2.0

### DIFF
--- a/patch/djcross-gcc-7.2.0.patch
+++ b/patch/djcross-gcc-7.2.0.patch
@@ -1,0 +1,11 @@
+--- gmp-6.1.2/configure.orig	2026-05-28 21:31:41.000403593 +0200
++++ gmp-6.1.2/configure	2026-05-28 21:36:28.248055255 +0200
+@@ -6458,7 +6458,7 @@
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int i, t1 *src, t1 n, t1 *got, t1 *want, int n2){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}

--- a/patch/patch-djlsr205.txt
+++ b/patch/patch-djlsr205.txt
@@ -158,3 +158,15 @@ diff -ur djlsr205-orig/src/stub/exe2coff.c djlsr205/src/stub/exe2coff.c
  
  static void
  exe2aout(char *fname)
+diff -u djlsr205-orig/src/djasm/djasm.y djlsr205/src/djasm/djasm.y
+--- djlsr205-orig/src/djasm/djasm.y	2026-05-28 21:57:14.871321442 +0200
++++ djlsr205/src/djasm/djasm.y	2026-05-28 21:58:03.701196071 +0200
+@@ -179,7 +179,7 @@
+ void modrm(int mod, int reg, int rm);
+ void reg(int reg);
+ void addr32(int sib);
+-void sortsyms();
++void sortsyms(int (*sortf)(void const *,void const *));
+ 
+ int istemp(char *symname, char which);
+ int islocal(char *symname);

--- a/script/7.2.0
+++ b/script/7.2.0
@@ -245,6 +245,10 @@ cd -
 # copy stubify programs
 cp $DJGPP_PREFIX/i586-pc-msdosdjgpp/bin/stubify $BUILDDIR/tmpinst/bin
 
+echo "Patching gmp"
+cd $BUILDDIR
+patch -p0 < ../../patch/djcross-gcc-7.2.0.patch
+
 echo "Building gmp"
 cd $BUILDDIR/gmp-*/
 # On some systems, building gmp will fail if CFLAGS is set.


### PR DESCRIPTION
With GCC 15.2.0, compilation of DJGPP 7.2.0 fails due to some function declarations with empty parameter list.

This pull request has the purpose of allowing compilation of 7.2.0 with today's compilers.

If the "style" (file names etc.) is not right, just let me know and I will fix it.